### PR TITLE
Return exit code of underlying cmake execution

### DIFF
--- a/src/mk.cpp
+++ b/src/mk.cpp
@@ -1573,7 +1573,7 @@ int main(int argc, char** argv)
 		}
 	}
 
-	execute(cmd);
+	int exit_code = execute(cmd);
 
-	return 0;
+	return exit_code;
 }


### PR DESCRIPTION
This change makes it more easy to use makekit with automated build servers (e.g. jenkins jobs).